### PR TITLE
Fix report name encoding [BB-4529]

### DIFF
--- a/src/report-browser/ReportBrowser.jsx
+++ b/src/report-browser/ReportBrowser.jsx
@@ -29,7 +29,7 @@ ReportURLCell.propTypes = {
 function getViewInBrowserActionCellForCourse(courseId) {
   function ViewInBrowserActionCell({ row }) {
     return (
-      <Link to={`/instructor-reports/${courseId}/report/?reportName=${encodeURI(row.values.name)}`}>
+      <Link to={`/instructor-reports/${courseId}/report/?reportName=${encodeURIComponent(row.values.name)}`}>
         <FormattedMessage id="report-browser.report-list.table-column-action.view" defaultMessage="View" />
       </Link>
     );


### PR DESCRIPTION
Fix report name encoding

**Dependencies**: None

**Testing instructions**:

Generate a report that has a + in the name (for e.g. part of a usage key etc)
Test that the report is viewable in the browser. 


**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD

**Settings**
```yaml

```